### PR TITLE
Updateds for latest version of PredictionIO 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ client.create_event(
       entity_type="user",
       entity_id=str(count), # use the count num as user ID
       properties= {
-        "attr0" : int(attr[0]),
-        "attr1" : int(attr[1]),
-        "attr2" : int(attr[2]),
-		"attr3" : int(attr[3]),
-		"attr4" : int(attr[4]),
-		"attr5" : int(attr[5]),
-		"attr6" : int(attr[6]),
-		"attr7" : int(attr[7]),
-        "plan" : int(plan)
+        "attr0" : float(attr[0]),
+        "attr1" : float(attr[1]),
+        "attr2" : float(attr[2]),
+        "attr3" : float(attr[3]),
+        "attr4" : float(attr[4]),
+        "attr5" : float(attr[5]),
+        "attr6" : float(attr[6]),
+        "attr7" : float(attr[7]),
+        "plan" : float(plan)
       }
 ```
 ## Install and Run PredictionIO
-First you need to [install PredictionIO 0.9.1](http://docs.prediction.io/install/) (if you haven't done it).
+First you need to [install PredictionIO 0.12.1](https://predictionio.apache.org/install/) (if you haven't done it).
 Let's say you have installed PredictionIO at /home/yourname/PredictionIO/. For convenience, add PredictionIO's binary command path to your PATH, i.e. /home/yourname/PredictionIO/bin
 ```
 $ PATH=$PATH:/home/yourname/PredictionIO/bin; export PATH
@@ -216,6 +216,12 @@ import predictionio
 engine_client = predictionio.EngineClient(url="http://localhost:8000")
 print engine_client.send_query({"features" :[-1, -2, -1, -3, 0, 0, -1, 0]})
 
+```
+
+Sample Curl Request
+```
+curl -H "Content-Type: application/json" \
+-d '{ "features": [-1, -2, -1, -3, 0, 0, -1, 0] }' http://localhost:8000/queries.json
 ```
 The following is sample JSON response:
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,11 @@ assemblySettings
 
 name := "template-scala-parallel-vanilla"
 
-organization := "io.prediction"
+organization := "org.apache.predictionio"
+
+scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "io.prediction"    %% "core"          % pioVersion.value % "provided",
+  "org.apache.predictionio" %% "apache-predictionio-core" % pioVersion.value % "provided",
   "org.apache.spark" %% "spark-core"    % "1.2.0" % "provided",
   "org.apache.spark" %% "spark-mllib"   % "1.2.0" % "provided")

--- a/src/main/scala/Algorithm.scala
+++ b/src/main/scala/Algorithm.scala
@@ -1,7 +1,7 @@
 package org.template.vanilla
 
-import io.prediction.controller.P2LAlgorithm
-import io.prediction.controller.Params
+import org.apache.predictionio.controller.P2LAlgorithm
+import org.apache.predictionio.controller.Params
 
 
 import org.apache.spark.mllib.regression.LinearRegressionWithSGD

--- a/src/main/scala/DataSource.scala
+++ b/src/main/scala/DataSource.scala
@@ -1,11 +1,11 @@
 package org.template.vanilla
 
-import io.prediction.controller.PDataSource
-import io.prediction.controller.EmptyEvaluationInfo
-import io.prediction.controller.EmptyActualResult
-import io.prediction.controller.Params
-import io.prediction.data.storage.Event
-import io.prediction.data.storage.Storage
+import org.apache.predictionio.controller.PDataSource
+import org.apache.predictionio.controller.EmptyEvaluationInfo
+import org.apache.predictionio.controller.EmptyActualResult
+import org.apache.predictionio.controller.Params
+import org.apache.predictionio.data.storage.Event
+import org.apache.predictionio.data.storage.Storage
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -2,8 +2,8 @@
 package org.template.vanilla
 
 
-import io.prediction.controller.IEngineFactory
-import io.prediction.controller.Engine
+import org.apache.predictionio.controller.IEngineFactory
+import org.apache.predictionio.controller.Engine
 
 class Query(
   val features: Array[Double]

--- a/src/main/scala/Preparator.scala
+++ b/src/main/scala/Preparator.scala
@@ -1,6 +1,6 @@
 package org.template.vanilla
 
-import io.prediction.controller.PPreparator
+import org.apache.predictionio.controller.PPreparator
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Serving.scala
+++ b/src/main/scala/Serving.scala
@@ -1,6 +1,6 @@
 package org.template.vanilla
 
-import io.prediction.controller.LServing
+import org.apache.predictionio.controller.LServing
 
 class Serving extends LServing[Query, PredictedResult] {
 


### PR DESCRIPTION
Libraries in latest version of PredictionIO 0.12.1 are changed from from io.prediction to org.apache.predictionio.
Made necessary changes in Scala source code and in build.sbt
Updated the ReadMe to point to the latest installation URL